### PR TITLE
Add SMS provider strategy

### DIFF
--- a/sms-authenticator/README.md
+++ b/sms-authenticator/README.md
@@ -33,6 +33,13 @@ from the original authenticator provider [documentation](https://www.keycloak.or
    1. `Receiver Phone Number Attribute`: The attribute that contains the receiver phone number. For many APIs (i.e. GTX Messaging, SMS Eagle) this is `to`.
    1. `Sender Phone Number Attribute`: The attribute that contains the sender phone number. Leave empty if not required.
    1. `SenderId`: The sender ID is displayed as the message sender on the receiving device. This is the value for the `Sender Phone Number Attribute`.
+   1. `SMS Provider`: Select which provider to use (`generic`, `twilio`, `nexmo`). Choosing a provider reveals additional inputs for that provider.
+   1. `Twilio Account SID`: Required when using the `twilio` provider.
+   1. `Twilio Auth Token`: Required when using the `twilio` provider.
+   1. `Twilio From`: Sender number registered with Twilio.
+   1. `Nexmo API Key`: Required when using the `nexmo` provider.
+   1. `Nexmo API Secret`: Required when using the `nexmo` provider.
+   1. `Nexmo From`: Sender name or number for Nexmo.
 1. Go to `/admin/master/console/#/realm/authentication/required-actions` and enable required actions "Phone Validation" and "Update Mobile Number"
 
 # Usage

--- a/sms-authenticator/src/main/java/netzbegruenung/keycloak/authenticator/SmsAuthenticatorFactory.java
+++ b/sms-authenticator/src/main/java/netzbegruenung/keycloak/authenticator/SmsAuthenticatorFactory.java
@@ -70,9 +70,18 @@ public class SmsAuthenticatorFactory implements AuthenticatorFactory {
 	}
 
 	@Override
-	public List<ProviderConfigProperty> getConfigProperties() {
-		return List.of(
-			new ProviderConfigProperty("length", "Code length", "The number of digits of the generated code.", ProviderConfigProperty.STRING_TYPE, 6),
+        public List<ProviderConfigProperty> getConfigProperties() {
+                ProviderConfigProperty provider = new ProviderConfigProperty();
+                provider.setName("provider");
+                provider.setLabel("SMS Provider");
+                provider.setHelpText("Select the SMS provider implementation.");
+                provider.setType(ProviderConfigProperty.LIST_TYPE);
+                provider.setDefaultValue("generic");
+                provider.setOptions(List.of("generic", "twilio", "nexmo"));
+
+                return List.of(
+                        provider,
+                        new ProviderConfigProperty("length", "Code length", "The number of digits of the generated code.", ProviderConfigProperty.STRING_TYPE, 6),
 			new ProviderConfigProperty("ttl", "Time-to-live", "The time to live in seconds for the code to be valid.", ProviderConfigProperty.STRING_TYPE, "300"),
 			new ProviderConfigProperty("senderId", "SenderId", "The sender ID is displayed as the message sender on the receiving device.", ProviderConfigProperty.STRING_TYPE, "Keycloak"),
 			new ProviderConfigProperty("simulation", "Simulation mode", "In simulation mode, the SMS won't be sent, but printed to the server logs", ProviderConfigProperty.BOOLEAN_TYPE, true),
@@ -85,8 +94,14 @@ public class SmsAuthenticatorFactory implements AuthenticatorFactory {
 			new ProviderConfigProperty("messageattribute", "Message Attribute", "The attribute that contains the SMS message text.", ProviderConfigProperty.STRING_TYPE, "text"),
 			new ProviderConfigProperty("receiverattribute", "Receiver Phone Number Attribute", "The attribute that contains the receiver phone number.", ProviderConfigProperty.STRING_TYPE, "to"),
 			new ProviderConfigProperty("receiverJsonTemplate", "Receiver Phone Number Json value template", "Receiver value structure can be customised to match API requirements.", ProviderConfigProperty.STRING_TYPE, "\"%s\""),
-			new ProviderConfigProperty("senderattribute", "Sender Phone Number Attribute", "The attribute that contains the sender phone number. Leave empty if not required.", ProviderConfigProperty.STRING_TYPE, "from"),
-			new ProviderConfigProperty("forceSecondFactor", "Force 2FA", "If 2FA authentication is not configured, the user is forced to setup SMS Authentication.", ProviderConfigProperty.BOOLEAN_TYPE, false),
+                        new ProviderConfigProperty("senderattribute", "Sender Phone Number Attribute", "The attribute that contains the sender phone number. Leave empty if not required.", ProviderConfigProperty.STRING_TYPE, "from"),
+                        new ProviderConfigProperty("twilioAccountSid", "Twilio Account SID", "Account SID for Twilio API (required for Twilio provider).", ProviderConfigProperty.STRING_TYPE, ""),
+                        new ProviderConfigProperty("twilioAuthToken", "Twilio Auth Token", "Auth token for Twilio API (required for Twilio provider).", ProviderConfigProperty.PASSWORD, ""),
+                        new ProviderConfigProperty("twilioFrom", "Twilio From", "Sender phone number registered with Twilio.", ProviderConfigProperty.STRING_TYPE, ""),
+                        new ProviderConfigProperty("nexmoApiKey", "Nexmo API Key", "API key for Nexmo/Vonage SMS (required for Nexmo provider).", ProviderConfigProperty.STRING_TYPE, ""),
+                        new ProviderConfigProperty("nexmoApiSecret", "Nexmo API Secret", "API secret for Nexmo/Vonage SMS (required for Nexmo provider).", ProviderConfigProperty.PASSWORD, ""),
+                        new ProviderConfigProperty("nexmoFrom", "Nexmo From", "Sender name or number for Nexmo.", ProviderConfigProperty.STRING_TYPE, ""),
+                        new ProviderConfigProperty("forceSecondFactor", "Force 2FA", "If 2FA authentication is not configured, the user is forced to setup SMS Authentication.", ProviderConfigProperty.BOOLEAN_TYPE, false),
 			new ProviderConfigProperty("whitelist", "Excluded from enforced 2FA", "All users with the here selected role are not forced to setup 2FA.", ProviderConfigProperty.ROLE_TYPE, null),
 			new ProviderConfigProperty("hideResponsePayload", "Redacted API response log message", "Don't log API response body of SMS send request.", ProviderConfigProperty.BOOLEAN_TYPE, false),
 			new ProviderConfigProperty("mobileInputFieldPlaceholder", "Phone number input field placeholder", "The placeholder string user in the phone number input field", ProviderConfigProperty.STRING_TYPE, ""),

--- a/sms-authenticator/src/main/java/netzbegruenung/keycloak/authenticator/gateway/NexmoSmsService.java
+++ b/sms-authenticator/src/main/java/netzbegruenung/keycloak/authenticator/gateway/NexmoSmsService.java
@@ -1,0 +1,58 @@
+package netzbegruenung.keycloak.authenticator.gateway;
+
+import org.jboss.logging.Logger;
+
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.Charset;
+import java.util.Map;
+
+/**
+ * SmsService implementation using Vonage (formerly Nexmo) API.
+ */
+public class NexmoSmsService implements SmsService {
+
+    private static final Logger logger = Logger.getLogger(NexmoSmsService.class);
+
+    private final String apiKey;
+    private final String apiSecret;
+    private final String from;
+
+    public NexmoSmsService(Map<String, String> config) {
+        this.apiKey = config.get("nexmoApiKey");
+        this.apiSecret = config.get("nexmoApiSecret");
+        this.from = config.get("nexmoFrom");
+    }
+
+    @Override
+    public void send(String phoneNumber, String message) {
+        try {
+            String body = String.format("api_key=%s&api_secret=%s&to=%s&from=%s&text=%s",
+                    URLEncoder.encode(apiKey, Charset.defaultCharset()),
+                    URLEncoder.encode(apiSecret, Charset.defaultCharset()),
+                    URLEncoder.encode(phoneNumber, Charset.defaultCharset()),
+                    URLEncoder.encode(from, Charset.defaultCharset()),
+                    URLEncoder.encode(message, Charset.defaultCharset()));
+
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create("https://rest.nexmo.com/sms/json"))
+                    .header("Content-Type", "application/x-www-form-urlencoded")
+                    .POST(HttpRequest.BodyPublishers.ofString(body))
+                    .build();
+
+            HttpClient client = HttpClient.newHttpClient();
+            HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+
+            if (response.statusCode() >= 200 && response.statusCode() < 300) {
+                logger.infof("Sent SMS via Nexmo to %s", phoneNumber);
+            } else {
+                logger.errorf("Nexmo error %s while sending SMS to %s: %s", response.statusCode(), phoneNumber, response.body());
+            }
+        } catch (Exception e) {
+            logger.errorf(e, "Failed to send Nexmo SMS to %s", phoneNumber);
+        }
+    }
+}

--- a/sms-authenticator/src/main/java/netzbegruenung/keycloak/authenticator/gateway/SmsServiceFactory.java
+++ b/sms-authenticator/src/main/java/netzbegruenung/keycloak/authenticator/gateway/SmsServiceFactory.java
@@ -29,12 +29,17 @@ public class SmsServiceFactory {
 
 	private static final Logger logger = Logger.getLogger(SmsServiceFactory.class);
 
-	public static SmsService get(Map<String, String> config) {
-		if (Boolean.parseBoolean(config.getOrDefault("simulation", "false"))) {
-			return (phoneNumber, message) ->
-				logger.infof("***** SIMULATION MODE ***** Would send SMS to %s with text: %s", phoneNumber, message);
-		} else {
-			return new ApiSmsService(config);
-		}
-	}
+        public static SmsService get(Map<String, String> config) {
+                if (Boolean.parseBoolean(config.getOrDefault("simulation", "false"))) {
+                        return (phoneNumber, message) ->
+                                logger.infof("***** SIMULATION MODE ***** Would send SMS to %s with text: %s", phoneNumber, message);
+                }
+
+                String provider = config.getOrDefault("provider", "generic");
+                return switch (provider) {
+                        case "twilio" -> new TwilioSmsService(config);
+                        case "nexmo" -> new NexmoSmsService(config);
+                        default -> new ApiSmsService(config);
+                };
+        }
 }

--- a/sms-authenticator/src/main/java/netzbegruenung/keycloak/authenticator/gateway/TwilioSmsService.java
+++ b/sms-authenticator/src/main/java/netzbegruenung/keycloak/authenticator/gateway/TwilioSmsService.java
@@ -1,0 +1,63 @@
+package netzbegruenung.keycloak.authenticator.gateway;
+
+import org.jboss.logging.Logger;
+
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.Charset;
+import java.util.Base64;
+import java.util.Map;
+
+/**
+ * SmsService implementation using Twilio REST API.
+ */
+public class TwilioSmsService implements SmsService {
+
+    private static final Logger logger = Logger.getLogger(TwilioSmsService.class);
+
+    private final String accountSid;
+    private final String authToken;
+    private final String from;
+
+    public TwilioSmsService(Map<String, String> config) {
+        this.accountSid = config.get("twilioAccountSid");
+        this.authToken = config.get("twilioAuthToken");
+        this.from = config.get("twilioFrom");
+    }
+
+    @Override
+    public void send(String phoneNumber, String message) {
+        try {
+            String body = String.format("To=%s&From=%s&Body=%s",
+                    URLEncoder.encode(phoneNumber, Charset.defaultCharset()),
+                    URLEncoder.encode(from, Charset.defaultCharset()),
+                    URLEncoder.encode(message, Charset.defaultCharset()));
+
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create(String.format("https://api.twilio.com/2010-04-01/Accounts/%s/Messages.json", accountSid)))
+                    .header("Authorization", basicAuth(accountSid, authToken))
+                    .header("Content-Type", "application/x-www-form-urlencoded")
+                    .POST(HttpRequest.BodyPublishers.ofString(body))
+                    .build();
+
+            HttpClient client = HttpClient.newHttpClient();
+            HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+
+            if (response.statusCode() >= 200 && response.statusCode() < 300) {
+                logger.infof("Sent SMS via Twilio to %s", phoneNumber);
+            } else {
+                logger.errorf("Twilio error %s while sending SMS to %s: %s", response.statusCode(), phoneNumber, response.body());
+            }
+        } catch (Exception e) {
+            logger.errorf(e, "Failed to send Twilio SMS to %s", phoneNumber);
+        }
+    }
+
+    private static String basicAuth(String user, String pass) {
+        String value = user + ":" + pass;
+        return "Basic " + Base64.getEncoder().encodeToString(value.getBytes());
+    }
+}


### PR DESCRIPTION
## Summary
- add Twilio and Nexmo SMS service implementations
- select SMS provider in authenticator config
- update factory to choose provider implementation
- document provider options

## Testing
- `mvn -q -DskipTests package` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_68606ccb0220832580f45957c741d168